### PR TITLE
DEV-19699 Handle SEQUENCE in MSSQL via IDENTITY in any case

### DIFF
--- a/src/main/java/org/eclipse/persistence/platform/database/SQLServerPlatform.java
+++ b/src/main/java/org/eclipse/persistence/platform/database/SQLServerPlatform.java
@@ -699,7 +699,9 @@ public class SQLServerPlatform extends DatabasePlatform {
      */
     @Override
     public boolean supportsSequenceObjects() {
-        return isVersion11OrHigher;
+        // PATCHED Without this EclipseLink handles SEQUENCE field from old databases wrongly.
+        // See https://bugs.eclipse.org/bugs/show_bug.cgi?id=499233
+        return false;
     }
 
     /**

--- a/src/test/java/org/eclipse/persistence/platform/database/SQLServerPlatformTest.java
+++ b/src/test/java/org/eclipse/persistence/platform/database/SQLServerPlatformTest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * (C) 2019 Acrolinx GmbH. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.persistence.platform.database;
+
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SQLServerPlatformTest
+{
+    @Test
+    public void testDoesNotSupportsSequenceObjects() throws SQLException {
+        final Connection connection = mock(Connection.class);
+        final DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+        when(databaseMetaData.getDatabaseMajorVersion()).thenReturn(11);
+        when(databaseMetaData.getDriverVersion()).thenReturn("4.0.0");
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+
+        final SQLServerPlatform sqlServerPlatform = new SQLServerPlatform();
+        sqlServerPlatform.initializeConnectionData(connection);
+
+        assertFalse(sqlServerPlatform.supportsSequenceObjects());
+    }
+}


### PR DESCRIPTION
Otherwise EclipseLink may try to handle it via SEQUENCE, even
on older databases containing an IDENTITY column built with
older EclipseLink versions.
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=499233 for
details.